### PR TITLE
Use alt installer URL for TSKM C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ At home, sitting next to your router, turn on C3X with your phone charger. Ignor
 
 Choose `Custom Software` and enter the URL `optskug/tskm`
 
-If you have C3 (predecessor to C3X), enter `optskug/tskm-c3`
+If you have C3 (predecessor to C3X), enter `https://smiskol.com/fork/optskug/tskm-c3`
 
 ![](img/v4.install.1.jpg)
 


### PR DESCRIPTION
Comma installer seems to have "intelligence" in it that breaks C3 users

https://discord.com/channels/469524606043160576/905950538816978974/1424827736949653594