### PR TITLE
[codex] docs: clarify TSK caveat and add fork freshness badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is an attempt to document some of the discussion and information about the 
 
 ## Table of Contents
 
+<!-- toc:start -->
 * [openpilot/etc. on Toyota/Lexus/Subaru with TSK/ECU SECURITY KEY/SecOC](#openpilotetc-on-toyotalexussubaru-with-tskecu-security-keysecoc)
    * [Background](#background)
    * [Cars](#cars)
@@ -39,6 +40,7 @@ This is an attempt to document some of the discussion and information about the 
 * [Forks](#forks)
 * [Discords of Note](#discords-of-note)
 * [Current History](#current-history)
+<!-- toc:end -->
 
 ---
 
@@ -70,6 +72,11 @@ The following is not comprehensive.
 ---
 
 ## Cars
+
+> [!IMPORTANT]
+> TSS version alone does **not** tell you whether a vehicle has TSK/SecOC or whether the current exploit path will work. Region, model year, plant/origin, and the exact ECU hardware matter more.
+>
+> Example: the EU 2024 RAV4 Hybrid appears to have TSK, while the US 2025 RAV4 appears not to have TSK according to TechInfo checks. Do not assume "TSS 2.0" means "works" or "TSS 3.0" means "doesn't work".
 
 ### 🟢 Successfully running openpilot
 
@@ -509,6 +516,8 @@ Is a GUI button too easy for your engineering spirit? Here is how to [extract th
 
 ## openpilot
 
+[![nightly-dev last commit](https://img.shields.io/github/last-commit/commaai/openpilot/nightly-dev?label=nightly-dev%20last%20commit)](https://github.com/commaai/openpilot/commits/nightly-dev/)
+
 URL
 * C4: `commaai/nightly-dev`
 * C3X: `commaai/nightly-dev`
@@ -522,6 +531,10 @@ Notes
 * Supports lat and long, but no MADS/AOL.
 
 ## sunnypilot
+
+[![staging last commit](https://img.shields.io/github/last-commit/sunnypilot/sunnypilot/staging?label=staging%20last%20commit)](https://github.com/sunnypilot/sunnypilot/commits/staging/)
+[![release-tizi last commit](https://img.shields.io/github/last-commit/sunnypilot/sunnypilot/release-tizi?label=release-tizi%20last%20commit)](https://github.com/sunnypilot/sunnypilot/commits/release-tizi/)
+[![staging-tici last commit](https://img.shields.io/github/last-commit/sunnypilot/sunnypilot/staging-tici?label=staging-tici%20last%20commit)](https://github.com/sunnypilot/sunnypilot/commits/staging-tici/)
 
 URL [(Source)](https://community.sunnypilot.ai/t/recommended-branch-installations/235)
 * C4: `staging.sunnypilot.ai`
@@ -538,6 +551,8 @@ Notes
 
 ## FrogPilot
 
+[![FrogPilot last commit](https://img.shields.io/github/last-commit/FrogAi/FrogPilot/FrogPilot?label=FrogPilot%20last%20commit)](https://github.com/FrogAi/FrogPilot/commits/FrogPilot/)
+
 URL
 * C4: Not yet supported
 * C3X: `frogpilot.download`
@@ -549,6 +564,9 @@ Notes
 * Discord: https://discord.com/invite/frogpilot
 
 ## SatoPilot
+
+[![personal3 last commit](https://img.shields.io/github/last-commit/AlexandreSato/openpilot/personal3?label=personal3%20last%20commit)](https://github.com/AlexandreSato/openpilot/commits/personal3/)
+[![extract_secoc_key_btn last commit](https://img.shields.io/github/last-commit/AlexandreSato/openpilot/extract_secoc_key_btn?label=extract_secoc_key_btn%20last%20commit)](https://github.com/AlexandreSato/openpilot/commits/extract_secoc_key_btn/)
 
 URL
 * C4: Not yet supported


### PR DESCRIPTION
## What changed
- add a prominent README note that TSS version alone is not enough to determine TSK/SecOC compatibility
- add freshness badges for the documented openpilot, sunnypilot, FrogPilot, and SatoPilot branches
- wrap the existing README table of contents in markers so a follow-up TOC sync script can manage it safely

## Why
- the new note makes an easy-to-miss compatibility caveat much more obvious near the car list
- the badges give readers a quick signal for how active each recommended branch is
- the TOC markers prepare the README for a follow-up automation PR without changing the current TOC contents

## Validation
- `git diff --check`
- verified each badge branch exists with `git ls-remote --heads`
